### PR TITLE
Set sys name with lldptool

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,10 @@ lldp_service_name:
       'FreeBSD': 'lldpd'
       'RedHat': 'lldpad'
       'Debian': 'lldpd'
+      
+#
+lldp_transmit_sysname: True
+lldp_sysname_interfaces: 
+ - "em1"
+lldp_tlvs:
+ - { id: "sysName", enableTx: "yes" }

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: restart lldpad
   service:
-    name: lldpad
+    name: "{{ lldp_service_name[ansible_os_family] }}"
     state: restarted
 
 # vim:ft=ansible:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: restart lldpad
+  service:
+    name: lldpad
+    state: restarted
+
+# vim:ft=ansible:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: ensure lldpd is started and available at boot
   service: name="{{ lldp_service_name[ansible_os_family] }}" state=started enabled=yes
 
-- name: transmit tlvs
+- name: transmit tlvs with lldptool on RedHat
   command: "lldptool -i {{ item[0] }} -T -V {{ item[1].id }} enableTx={{ item[1].enableTx }}"
   with_nested: 
    - "{{ ansible_interfaces }}"
@@ -18,5 +18,6 @@
    - (ansible_{{ item[0] }}['type'] != "loopback" and ansible_{{ item[0] }}['type'] is defined)
    - item[0] in lldp_sysname_interfaces
    - reg_lldpd_install_package.changed
+   - ansible_os_family == "RedHat"
   notify:
    - restart lldpad

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,3 +16,5 @@
    - ansible_{{ item[0] }}['active'] == true 
    - (ansible_{{ item[0] }}['type'] != "loopback" and ansible_{{ item[0] }}['type'] is defined)
    - item[0] in lldp_sysname_interfaces
+  notify:
+   - restart lldpad

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 # tasks file for bvansomeren.lldpd
 - name: ensure lldpd is installed
   package: name="{{ lldp_package_name[ansible_os_family] }}" state=present
+  register: reg_lldpd_install_package
 
 - name: ensure lldpd is started and available at boot
   service: name="{{ lldp_service_name[ansible_os_family] }}" state=started enabled=yes
@@ -16,5 +17,6 @@
    - ansible_{{ item[0] }}['active'] == true 
    - (ansible_{{ item[0] }}['type'] != "loopback" and ansible_{{ item[0] }}['type'] is defined)
    - item[0] in lldp_sysname_interfaces
+   - reg_lldpd_install_package.changed
   notify:
    - restart lldpad

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,3 +6,13 @@
 - name: ensure lldpd is started and available at boot
   service: name="{{ lldp_service_name[ansible_os_family] }}" state=started enabled=yes
 
+- name: transmit tlvs
+  command: "lldptool -i {{ item[0] }} -T -V {{ item[1].id }} enableTx={{ item[1].enableTx }}"
+  with_nested: 
+   - "{{ ansible_interfaces }}"
+   - "{{ lldp_tlvs }}"
+  when: 
+   - lldp_transmit_sysname 
+   - ansible_{{ item[0] }}['active'] == true 
+   - (ansible_{{ item[0] }}['type'] != "loopback" and ansible_{{ item[0] }}['type'] is defined)
+   - item[0] in lldp_sysname_interfaces


### PR DESCRIPTION
Hello!

Thanks for a good place to start :)

This change makes this role also set the sysName (and any other TLVs for interfaces listed in the variable). It also makes sure that the interface is not a loopback, has a type and is an active interface.

Looks like this from the switch:

<pre>
Interface RemID   Chassis ID          Port ID           System Name
--------- ------- ------------------- ----------------- -----------------
Gi1/0/12  3       AA:BB:CC:DD:EE:FF   AA:BB:CC:DD:EE:FF   computer1
</pre>

Rather than with an empty system name. At least this is how it is on RHEL7. If you know of another way to make it transmit sysName other than using the lldaptool then that could be a way around my issues below:

Unfortunately the command task changes every time - so the handler will also restart lldpad every time the role runs. I tried in https://github.com/CSC-IT-Center-for-Science/ansible-lldpd/blob/lldptool/tasks/main.yml to figure out the correct ansible syntax to:
 - first run "lldptool -i {{ item }} -t -V sysName" to see if sysName is set
 - create a list of interfaces we could set it on
 - then only run "lldptool -i {{ item }} -T -V sysName enableTx=yes" only on those interfaces

But my brain exploded and I couldn't figure it out.

How about if we only configure it once - during install?