### PR TITLE
Warnings fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Pretty much none. Only useful for hardware deployments
 Role Variables
 --------------
 
-None at this point
+See defaults/main.yml
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ansible-lldpd
 =========
-[![Build Status](https://travis-ci.org/CSC-IT-Center-for-Science/ansible-lldpd.svg?branch=master)](https://travis-ci.org/CSC-IT-Center-for-Science/ansible-lldpd)
+[![Build Status](https://travis-ci.org/CSCfi/ansible-lldpd.svg?branch=master)](https://travis-ci.org/CSCfi/ansible-lldpd)
 
 Installs LLDP on versions of Linux and FreeBSD. You probably want to learn why here: https://en.wikipedia.org/wiki/Link_Layer_Discovery_Protocol
 There is no real configuration required. By default this will emit the server name to the switches

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-bvansomeren.lldpd
+ansible-lldpd
 =========
-[![Build Status](https://travis-ci.org/bvansomeren/ansible-lldpd.svg?branch=master)](https://travis-ci.org/bvansomeren/ansible-lldpd)
+[![Build Status](https://travis-ci.org/CSC-IT-Center-for-Science/ansible-lldpd.svg?branch=master)](https://travis-ci.org/CSC-IT-Center-for-Science/ansible-lldpd)
 
 Installs LLDP on versions of Linux and FreeBSD. You probably want to learn why here: https://en.wikipedia.org/wiki/Link_Layer_Discovery_Protocol
 There is no real configuration required. By default this will emit the server name to the switches

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,10 @@ lldp_service_name:
       'FreeBSD': 'lldpd'
       'RedHat': 'lldpad'
       'Debian': 'lldpd'
+      
+#
+lldp_transmit_sysname: True
+lldp_sysname_interfaces: 
+ - "em1"
+lldp_tlvs:
+ - { id: "sysName", enableTx: "yes" }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,3 +19,6 @@ lldp_sysname_interfaces:
  - "{{ internal_interface | default('em1') }}"
 lldp_tlvs:
  - { id: "sysName", enableTx: "yes" }
+
+# The lldp daemon leaks memory a lot. Restart every week?
+lldp_autorestart: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 # defaults file for bvansomeren.lldpd
+lldp_enable: True
 lldp_package_name:
       'FreeBSD': 'openlldp'
       'RedHat': 'lldpad'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,8 @@ lldp_service_name:
       
 #
 lldp_transmit_sysname: True
+# define lldp_sysname_force and we will not enable transmit of sysName when lldpd was just installed but every time
+# lldp_sysname_force: True
 lldp_sysname_interfaces: 
  - "{{ internal_interface | default('em1') }}"
 lldp_tlvs:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: restart lldpad
   service:
-    name: lldpad
+    name: "{{ lldp_service_name[ansible_os_family] }}"
     state: restarted
 
 # vim:ft=ansible:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: restart lldpad
+  service:
+    name: lldpad
+    state: restarted
+
+# vim:ft=ansible:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,5 +3,6 @@
   service:
     name: "{{ lldp_service_name[ansible_os_family] }}"
     state: restarted
+  when: ansible_connection != 'chroot'
 
 # vim:ft=ansible:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,19 +18,19 @@
     - lldp_enable
     - ansible_virtualization_role != "guest" or ansible_virtualization_role != "NA"
 
-- name: transmit tlvs with lldptool on RedHat
+- name: transmit tlvs with lldptool on RedHat if we just installed lldpd
   command: "lldptool -i {{ item[0] }} -T -V {{ item[1].id }} enableTx={{ item[1].enableTx }}"
   with_nested: 
     - "{{ ansible_interfaces }}"
     - "{{ lldp_tlvs }}"
   when: 
-    - lldp_enable
-    - lldp_transmit_sysname 
-    - ansible_{{ item[0] }}['active'] == true 
-    - (ansible_{{ item[0] }}['type'] != "loopback" and ansible_{{ item[0] }}['type'] is defined)
-    - item[0] in lldp_sysname_interfaces
-    - reg_lldpd_install_package.changed
+    - lldp_enable # defaults to True
+    - lldp_transmit_sysname  # defaults to True
+    - ansible_{{ item[0] }}['active'] == true # only active interfaces
+    - (ansible_{{ item[0] }}['type'] != "loopback" and ansible_{{ item[0] }}['type'] is defined) # IB interfaces has no type with ansible 2.2
+    - item[0] in lldp_sysname_interfaces # this list only has "em1" by default
+    - reg_lldpd_install_package.changed # only set this once and when we just installed lldp
     - ansible_os_family == "RedHat"
-    - ansible_virtualization_role != "guest" or ansible_virtualization_role != "NA"
+    - ansible_virtualization_role != "guest" or ansible_virtualization_role != "NA" # not on virtual machines or where ansible can't detect
   notify:
     - restart lldpad

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: ensure lldpd is started and available at boot
   service: name="{{ lldp_service_name[ansible_os_family] }}" state=started enabled=yes
 
-- name: transmit tlvs
+- name: transmit tlvs with lldptool on RedHat
   command: "lldptool -i {{ item[0] }} -T -V {{ item[1].id }} enableTx={{ item[1].enableTx }}"
   with_nested: 
    - "{{ ansible_interfaces }}"
@@ -18,5 +18,6 @@
    - (ansible_{{ item[0] }}['type'] != "loopback" and ansible_{{ item[0] }}['type'] is defined)
    - item[0] in lldp_sysname_interfaces
    - reg_lldpd_install_package.changed
+   - ansible_os_family == "RedHat"
   notify:
    - restart lldpad

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,9 +3,11 @@
 - name: ensure lldpd is installed
   package: name="{{ lldp_package_name[ansible_os_family] }}" state=present
   register: reg_lldpd_install_package
+  when: lldp_enable
 
 - name: ensure lldpd is started and available at boot
   service: name="{{ lldp_service_name[ansible_os_family] }}" state=started enabled=yes
+  when: lldp_enable
 
 - name: transmit tlvs
   command: "lldptool -i {{ item[0] }} -T -V {{ item[1].id }} enableTx={{ item[1].enableTx }}"
@@ -13,6 +15,7 @@
    - "{{ ansible_interfaces }}"
    - "{{ lldp_tlvs }}"
   when: 
+   - lldp_enable
    - lldp_transmit_sysname 
    - ansible_{{ item[0] }}['active'] == true 
    - (ansible_{{ item[0] }}['type'] != "loopback" and ansible_{{ item[0] }}['type'] is defined)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
     - ansible_{{ item[0] }}['active'] == true # only active interfaces
     - (ansible_{{ item[0] }}['type'] != "loopback" and ansible_{{ item[0] }}['type'] is defined) # IB interfaces has no type with ansible 2.2
     - item[0] in lldp_sysname_interfaces # this list only has "em1" by default
-    - reg_lldpd_install_package.changed # only set this once and when we just installed lldp
+    - reg_lldpd_install_package.changed or lldp_sysname_force is defined # only when we just installed lldp or if lldp_sysname_force is defined
     - ansible_os_family == "RedHat"
     - ansible_virtualization_role != "guest" or ansible_virtualization_role != "NA" # not on virtual machines or where ansible can't detect
   notify:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,31 +1,36 @@
 ---
 # tasks file for bvansomeren.lldpd
 - name: ensure lldpd is installed
-  package: name="{{ lldp_package_name[ansible_os_family] }}" state=present
+  package: 
+    name: "{{ lldp_package_name[ansible_os_family] }}" 
+    state: present
   register: reg_lldpd_install_package
   when: 
     - lldp_enable
-    - ansible_virtualization_role != "guest"
+    - ansible_virtualization_role != "guest" or ansible_virtualization_role != "NA"
 
 - name: ensure lldpd is started and available at boot
-  service: name="{{ lldp_service_name[ansible_os_family] }}" state=started enabled=yes
+  service: 
+    name: "{{ lldp_service_name[ansible_os_family] }}" 
+    state: started 
+    enabled: yes
   when: 
     - lldp_enable
-    - ansible_virtualization_role != "guest"
+    - ansible_virtualization_role != "guest" or ansible_virtualization_role != "NA"
 
 - name: transmit tlvs with lldptool on RedHat
   command: "lldptool -i {{ item[0] }} -T -V {{ item[1].id }} enableTx={{ item[1].enableTx }}"
   with_nested: 
-   - "{{ ansible_interfaces }}"
-   - "{{ lldp_tlvs }}"
+    - "{{ ansible_interfaces }}"
+    - "{{ lldp_tlvs }}"
   when: 
-   - lldp_enable
-   - lldp_transmit_sysname 
-   - ansible_{{ item[0] }}['active'] == true 
-   - (ansible_{{ item[0] }}['type'] != "loopback" and ansible_{{ item[0] }}['type'] is defined)
-   - item[0] in lldp_sysname_interfaces
-   - reg_lldpd_install_package.changed
-   - ansible_os_family == "RedHat"
-   - ansible_virtualization_role != "guest"
+    - lldp_enable
+    - lldp_transmit_sysname 
+    - ansible_{{ item[0] }}['active'] == true 
+    - (ansible_{{ item[0] }}['type'] != "loopback" and ansible_{{ item[0] }}['type'] is defined)
+    - item[0] in lldp_sysname_interfaces
+    - reg_lldpd_install_package.changed
+    - ansible_os_family == "RedHat"
+    - ansible_virtualization_role != "guest" or ansible_virtualization_role != "NA"
   notify:
-   - restart lldpad
+    - restart lldpad

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
     - ansible_virtualization_role != "guest" or ansible_virtualization_role != "NA"
 
 - name: transmit tlvs with lldptool on RedHat if we just installed lldpd
-  command: "lldptool -i {{ item[0] }} -T -V {{ item[1].id }} enableTx={{ item[1].enableTx }}"
+  command: "/usr/sbin/lldptool -i {{ item[0] }} -T -V {{ item[1].id }} enableTx={{ item[1].enableTx }}"
   with_nested: 
     - "{{ ansible_interfaces }}"
     - "{{ lldp_tlvs }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,3 +35,17 @@
     - ansible_virtualization_role != "guest" or ansible_virtualization_role != "NA" # not on virtual machines or where ansible can't detect
   notify:
     - restart lldpad
+
+# On bigger clusters lldpad leaks memory like crazy (hundreds of megabytes to gigabytes of memory per week)
+# Restart it weekly during the night
+- name: "Add cronjob to restart {{ lldp_service_name[ansible_os_family] }} every week"
+  cron:
+    name: Cronjob to restart memoryleaking lldpad
+    state: present
+    weekday: 1
+    minute: 20
+    hour: 0
+    job: "systemctl restart {{ lldp_service_name[ansible_os_family] }}"
+  when:
+    - lldp_autorestart
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,13 @@
   when: 
     - lldp_enable
     - ansible_virtualization_role != "guest" or ansible_virtualization_role != "NA"
+    - ansible_connection != 'chroot'
+
+- name: enable lldpd in chroot images
+  command: systemctl enable {{ lldp_service_name[ansible_os_family] }}
+  when:
+    - lldp_enable
+    - ansible_connection == 'chroot'
 
 - name: transmit tlvs with lldptool on RedHat if we just installed lldpd
   command: "/usr/sbin/lldptool -i {{ item[0] }} -T -V {{ item[1].id }} enableTx={{ item[1].enableTx }}"
@@ -33,6 +40,7 @@
     - reg_lldpd_install_package.changed or lldp_sysname_force is defined # only when we just installed lldp or if lldp_sysname_force is defined
     - ansible_os_family == "RedHat"
     - ansible_virtualization_role != "guest" or ansible_virtualization_role != "NA" # not on virtual machines or where ansible can't detect
+    - ansible_connection != 'chroot'
   notify:
     - restart lldpad
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,11 +3,15 @@
 - name: ensure lldpd is installed
   package: name="{{ lldp_package_name[ansible_os_family] }}" state=present
   register: reg_lldpd_install_package
-  when: lldp_enable
+  when: 
+    - lldp_enable
+    - ansible_virtualization_role != "guest"
 
 - name: ensure lldpd is started and available at boot
   service: name="{{ lldp_service_name[ansible_os_family] }}" state=started enabled=yes
-  when: lldp_enable
+  when: 
+    - lldp_enable
+    - ansible_virtualization_role != "guest"
 
 - name: transmit tlvs with lldptool on RedHat
   command: "lldptool -i {{ item[0] }} -T -V {{ item[1].id }} enableTx={{ item[1].enableTx }}"
@@ -22,5 +26,6 @@
    - item[0] in lldp_sysname_interfaces
    - reg_lldpd_install_package.changed
    - ansible_os_family == "RedHat"
+   - ansible_virtualization_role != "guest"
   notify:
    - restart lldpad

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,3 +16,5 @@
    - ansible_{{ item[0] }}['active'] == true 
    - (ansible_{{ item[0] }}['type'] != "loopback" and ansible_{{ item[0] }}['type'] is defined)
    - item[0] in lldp_sysname_interfaces
+  notify:
+   - restart lldpad

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,9 +33,9 @@
   when: 
     - lldp_enable # defaults to True
     - lldp_transmit_sysname  # defaults to True
-    - (ansible_{{ item[0] }} is defined) # only if there are facts available for this interface
-    - (ansible_{{ item[0] }}['active'] == true) # only active interfaces
-    - (ansible_{{ item[0] }}['type'] != "loopback" and ansible_{{ item[0] }}['type'] is defined) # IB interfaces has no type with ansible 2.2
+    - vars['ansible_' ~ item[0]] is defined # only if there are facts available for this interface
+    - vars['ansible_' ~ item[0]]['active'] == true # only active interfaces
+    - vars['ansible_' ~ item[0]]['type'] != "loopback" and vars['ansible_' ~ item[0]]['type'] is defined # IB interfaces has no type with ansible 2.2
     - item[0] in lldp_sysname_interfaces # this list only has variable internal_interface or "em1" if that is not defined by default
     - reg_lldpd_install_package.changed or lldp_sysname_force is defined # only when we just installed lldp or if lldp_sysname_force is defined
     - ansible_os_family == "RedHat"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 # tasks file for bvansomeren.lldpd
 - name: ensure lldpd is installed
   package: name="{{ lldp_package_name[ansible_os_family] }}" state=present
+  register: reg_lldpd_install_package
 
 - name: ensure lldpd is started and available at boot
   service: name="{{ lldp_service_name[ansible_os_family] }}" state=started enabled=yes
@@ -16,5 +17,6 @@
    - ansible_{{ item[0] }}['active'] == true 
    - (ansible_{{ item[0] }}['type'] != "loopback" and ansible_{{ item[0] }}['type'] is defined)
    - item[0] in lldp_sysname_interfaces
+   - reg_lldpd_install_package.changed
   notify:
    - restart lldpad

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,3 +6,13 @@
 - name: ensure lldpd is started and available at boot
   service: name="{{ lldp_service_name[ansible_os_family] }}" state=started enabled=yes
 
+- name: transmit tlvs
+  command: "lldptool -i {{ item[0] }} -T -V {{ item[1].id }} enableTx={{ item[1].enableTx }}"
+  with_nested: 
+   - "{{ ansible_interfaces }}"
+   - "{{ lldp_tlvs }}"
+  when: 
+   - lldp_transmit_sysname 
+   - ansible_{{ item[0] }}['active'] == true 
+   - (ansible_{{ item[0] }}['type'] != "loopback" and ansible_{{ item[0] }}['type'] is defined)
+   - item[0] in lldp_sysname_interfaces

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,14 +21,15 @@
 - name: transmit tlvs with lldptool on RedHat if we just installed lldpd
   command: "/usr/sbin/lldptool -i {{ item[0] }} -T -V {{ item[1].id }} enableTx={{ item[1].enableTx }}"
   with_nested: 
-    - "{{ ansible_interfaces }}"
+    - "{{ ansible_interfaces|replace('.','') }}" # skip vlan interfaces
     - "{{ lldp_tlvs }}"
   when: 
     - lldp_enable # defaults to True
     - lldp_transmit_sysname  # defaults to True
-    - ansible_{{ item[0] }}['active'] == true # only active interfaces
+    - (ansible_{{ item[0] }} is defined) # only if there are facts available for this interface
+    - (ansible_{{ item[0] }}['active'] == true) # only active interfaces
     - (ansible_{{ item[0] }}['type'] != "loopback" and ansible_{{ item[0] }}['type'] is defined) # IB interfaces has no type with ansible 2.2
-    - item[0] in lldp_sysname_interfaces # this list only has "em1" by default
+    - item[0] in lldp_sysname_interfaces # this list only has variable internal_interface or "em1" if that is not defined by default
     - reg_lldpd_install_package.changed or lldp_sysname_force is defined # only when we just installed lldp or if lldp_sysname_force is defined
     - ansible_os_family == "RedHat"
     - ansible_virtualization_role != "guest" or ansible_virtualization_role != "NA" # not on virtual machines or where ansible can't detect


### PR DESCRIPTION
This fixes the warning:
[WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}.

..as suggested here by "sivel" replying to "MichalTaratuta":
https://github.com/ansible/ansible/issues/22397